### PR TITLE
add ans variable that hold previous result value

### DIFF
--- a/natpl-cli/src/main.rs
+++ b/natpl-cli/src/main.rs
@@ -109,7 +109,7 @@ fn print_response_line(
         name.map(|(name, width)| format!("{:width$} {} ", name, "=".bright_black(), width = width));
     let line = format!(
         "{}{:expr_pad$} {}{}{}",
-        name_part.unwrap_or_else(|| String::new()),
+        name_part.unwrap_or_else(String::new),
         value.to_string(),
         "[".bright_black(),
         unit_name.bright_blue(),

--- a/natpl-repl/src/lib.rs
+++ b/natpl-repl/src/lib.rs
@@ -40,6 +40,8 @@ pub enum ReadEvalResult {
     },
 }
 
+const ANS_NAME: &str = "ans";
+
 pub fn read_eval(rt: &mut Runtime, input: &str) -> ReadEvalResult {
     let toks = tokenising::tokenise(input);
     match Parser::parse_line(&toks) {
@@ -51,15 +53,21 @@ pub fn read_eval(rt: &mut Runtime, input: &str) -> ReadEvalResult {
 
             match res {
                 EvalResult::Empty => ReadEvalResult::Empty,
-                EvalResult::Value(val) => ReadEvalResult::SilentValue {
-                    display_candidates: unit_matches(rt, &val).collect(),
-                    value: val,
-                },
-                EvalResult::PrintValue(expr, val) => ReadEvalResult::PrintValue {
-                    expr,
-                    display_candidates: unit_matches(rt, &val).collect(),
-                    value: val,
-                },
+                EvalResult::Value(val) => {
+                    let _ = rt.set_variable(ANS_NAME, val.clone());
+                    ReadEvalResult::SilentValue {
+                        display_candidates: unit_matches(rt, &val).collect(),
+                        value: val,
+                    }
+                }
+                EvalResult::PrintValue(expr, val) => {
+                    let _ = rt.set_variable(ANS_NAME, val.clone());
+                    ReadEvalResult::PrintValue {
+                        expr,
+                        display_candidates: unit_matches(rt, &val).collect(),
+                        value: val,
+                    }
+                }
                 EvalResult::VariableSearchResult {
                     unit_aliases,
                     variables,

--- a/natpl/src/runtime.rs
+++ b/natpl/src/runtime.rs
@@ -42,6 +42,14 @@ impl Runtime {
         Default::default()
     }
 
+    pub fn get_variable(&self, name: &str) -> Option<Value> {
+        self.variables.get(name).cloned()
+    }
+
+    pub fn set_variable(&mut self, name: &str, value: Value) {
+        let _ = self.variables.insert(name.to_string(), value);
+    }
+
     pub fn eval_line_item(
         &mut self,
         item: LineItem,


### PR DESCRIPTION
~~at the moment this gets directly added to the `natpl` crate, maybe it's better to live in the `repl` crate instead?~~

The code inserting the `ans` value was moved to the `natpl-repl` crate instead.