### PR TITLE
Add Common Scientific Units to Prelude

### DIFF
--- a/lib/imperial.nat
+++ b/lib/imperial.nat
@@ -31,6 +31,9 @@ unit acre = 4840 yard^2
 unit cord = 128 foot^3
 unit board_foot = 114 inch^3
 
+# Very scientific. :)
+unit football_field = 100 yard
+
 unit fahrenheit
 
 conv x: celsius ⇒ fahrenheit = (9/5 celsius) + 32

--- a/lib/prelude.nat
+++ b/lib/prelude.nat
@@ -59,7 +59,7 @@ unit astronomical_unit = 149597870700 m
 unit AU = astronomical_unit
 unit au = astronomical_unit
 
-unit lightsecond = c m
+unit lightsecond = c * 1 s
 unit lightyear = 365.25 day / second * lightsecond
 unit ly = lightyear
 

--- a/lib/prelude.nat
+++ b/lib/prelude.nat
@@ -43,3 +43,25 @@ unit °C = celsius
 
 conv x:K ⇒ °C = (x / K)°C - 273.15°C
 conv x:°C ⇒ K = (x/°C + 273.15)K
+
+unit joule = kg * (m / s)^2
+unit J = joule
+
+unit angstrom = 100 pm
+unit ångström = angstrom
+unit Å = angstrom
+
+unit micron = μm
+
+c = 299792458
+
+unit astronomical_unit = 149597870700 m
+unit AU = astronomical_unit
+unit au = astronomical_unit
+
+unit lightsecond = c m
+unit lightyear = 365.25 day / second * lightsecond
+unit ly = lightyear
+
+unit parsec = 648000 au / pi
+unit pc = parsec

--- a/lib/prelude.nat
+++ b/lib/prelude.nat
@@ -53,7 +53,7 @@ unit Å = angstrom
 
 unit micron = μm
 
-c = 299792458
+c = 299792458 m/s
 
 unit astronomical_unit = 149597870700 m
 unit AU = astronomical_unit


### PR DESCRIPTION
This pull request adds common [units of length](https://en.wikipedia.org/wiki/Unit_of_length) among other scientific units.
- constants
	- speed of light in a vacuum (`c`) 
- energy
	- joules (J)
- microscopic distances
	- angstroms (Å)
	- microns (μm)
- astronomical distances
	- astronomical units (AU)
	- lightseconds (ls)
	- lightyears (ly)
	- parsecs (pc)
- _extremely scientific_ informal analogies
	- American football fields (equivalent to 100 Imperial yards)