### PR TITLE
add simple shell.nix and package.nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,21 @@
+{
+  pkgs,
+  rustPlatform,
+  version ? "0.1.0-git",
+  ...
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "natpl";
+  inherit version;
+  src = ./.;
+  cargoLock.lockFile = ./Cargo.lock;
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+    gnum4
+  ];
+  buildInputs = with pkgs; [
+    mpfr
+    gmp
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{
+  pkgs ? import <nixpkgs> {},
+  ...
+}:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    rustc
+    cargo
+    rustfmt
+    clippy
+    rust-analyzer
+    pkg-config
+    gnum4
+  ];
+  buildInputs = with pkgs; [
+    mpfr.dev
+    gmp.dev
+  ];
+}


### PR DESCRIPTION
hi, this makes it possible to import the package into a nix config using standard `callPackage` like this:

```nix
let
  pkgs = import <nixpkgs> {};
  src = builtins.fetchTarball "https://github.com/hydrolarus/natpl/archive/76180ea89601b0b00ae269e8b248ea05fd32ceb2.tar.gz";
in
  pkgs.callPackage "${src}/package.nix" {}
```

neither the `shell.nix` or the `package.nix` pins nixpkgs or rust or anything else and it uses the committed `Cargo.lock`, hopefully making it as low maintenance as possible